### PR TITLE
CFP 제출 폼 링크 비활성화

### DIFF
--- a/teaser-front/components/contribute/GotoContribute.tsx
+++ b/teaser-front/components/contribute/GotoContribute.tsx
@@ -43,9 +43,7 @@ function GotoContribute() {
                 <h1>파이콘 한국 2021 기여하기</h1>
                 <h3>
                     <span>
-                        <Link href="https://docs.google.com/forms/d/e/1FAIpQLSfzxutOlm01HZ_g_ZMmb1zAWIsF48hzZLzUUqtuNFTikNUY2g/viewform">
-                            <a target="_blank">파이콘 한국 2021 CFP 폼 →</a>
-                        </Link>
+                        파이콘 한국 2021 CFP 신청이 마감되었습니다.
                     </span>
                 </h3>
             </GuideContributeBlock>

--- a/teaser-front/styles/globals.css
+++ b/teaser-front/styles/globals.css
@@ -20,4 +20,5 @@ a {
 
 h1, h2, h3, h4 {
     word-break: keep-all;
+    line-height: 1.35;
 }


### PR DESCRIPTION
- CFP 제출 기한이 지났음에도 폼이 열려있어서 링크 삭제 처리했습니다.
- 모바일 기기로 웹사이트 접속시 제목의 line-height가 좁아 스타일을 수정했습니다.